### PR TITLE
ND TCAS Display fixes

### DIFF
--- a/plugins/xtlua/scripts/B747.60.xt.fltInst/B747.60.xt.fltInst02.lua
+++ b/plugins/xtlua/scripts/B747.60.xt.fltInst/B747.60.xt.fltInst02.lua
@@ -999,9 +999,7 @@ function B747_nd_traffic_capt_switch_CMDhandler(phase, duration)
         --simCMD_EFIS_tcas:once()
 	B747DR_nd_capt_tfc=1-B747DR_nd_capt_tfc
 	if B747DR_xpdr_sel_pos>2 then
-	  simDR_EFIS_tcas_on=B747DR_nd_capt_tfc
-	else
-	  simDR_EFIS_tcas_on=0
+	  simDR_EFIS_tcas_on=1
 	end
     elseif phase == 2 then
         B747DR_nd_traffic_capt_switch_pos = 0
@@ -1154,9 +1152,7 @@ function B747_nd_traffic_fo_switch_CMDhandler(phase, duration)
 	B747DR_nd_capt_tfc=1-B747DR_nd_capt_tfc
 	
 	if B747DR_xpdr_sel_pos>2 then
-	  simDR_EFIS_tcas_on=B747DR_nd_capt_tfc
-	else
-	  simDR_EFIS_tcas_on=0
+	  simDR_EFIS_tcas_on=1
 	end
     elseif phase == 2 then
         B747DR_nd_traffic_fo_switch_pos = 0


### PR DESCRIPTION
ND should not display the TCAS OFF message at any point that dataref `laminar/B747/flt_mgmt/txpdr/mode_sel_pos` < 3.

[FCOM](https://downloadoc.com/v/50378/download-747-flight-crew-operations-manual.html)
References used: pg. 101 (NP.11.2) and pg. 756 & 757 (10.10.53 & 10.10.54)

pg. 101 (NP.11.2):
![image](https://user-images.githubusercontent.com/24484463/101127627-92a34300-35c3-11eb-8874-ee55031005b3.png)

pg. 756 & 757 (10.10.53 & 10.10.54)
![image](https://user-images.githubusercontent.com/24484463/101128590-9b951400-35c5-11eb-9826-ba78c493e27f.png)