### PR TITLE
CG% & TRIM calcs plus cleanup of a few FMC pages

### DIFF
--- a/plugins/xtlua/init/scripts/B747.25.fuel/B747.25.fuel.lua
+++ b/plugins/xtlua/init/scripts/B747.25.fuel/B747.25.fuel.lua
@@ -355,7 +355,7 @@ B747DR_fuel_display_units_eicas			= deferred_dataref("laminar/B747/fuel/fuel_dis
 B747DR_fuel_preselect_temp				= deferred_dataref("laminar/B747/fuel/fuel_preselect_temp", "number")
 
 -- Holds all SimConfig options
-B747DR_simconfig_data					= deferred_dataref("laminar/B747/simconfig", "string")
+--B747DR_simconfig_data					= deferred_dataref("laminar/B747/simconfig", "string")
 
 --*************************************************************************************--
 --** 				              CREATE CUSTOM COMMANDS              			     **--

--- a/plugins/xtlua/init/scripts/B747.68.fms/B747.68.fms.lua
+++ b/plugins/xtlua/init/scripts/B747.68.fms/B747.68.fms.lua
@@ -27,6 +27,7 @@ irs_line1="TIME TO ALIGN"
 irs_line2="L OFF"
 irs_line3="C OFF"
 irs_line4="R OFF"
+
 function createFMSDatarefs(fmsid)
 create_dataref("laminar/B747/"..fmsid.."/Line01_L", "string")
 create_dataref("laminar/B747/"..fmsid.."/Line02_L", "string")
@@ -89,8 +90,8 @@ B747DR_ND_Wind_Bearing					= deferred_dataref("laminar/B747/nd/wind_bearing", "n
 
 function createFMSCommands(fmsO,cduid,fmsid,keyid,fmskeyid)
 B747CMD_fms1_ls_key_L1              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L1", fmsO.." Line Select Key 1-Left")
-  B747CMD_fms1_ls_key_L2            = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L2", fmsO.." Line Select Key 2-Left")
-  B747CMD_fms1_ls_key_L3            = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L3", fmsO.." Line Select Key 3-Left")
+B747CMD_fms1_ls_key_L2              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L2", fmsO.." Line Select Key 2-Left")
+B747CMD_fms1_ls_key_L3              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L3", fmsO.." Line Select Key 3-Left")
 B747CMD_fms1_ls_key_L4              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L4", fmsO.." Line Select Key 4-Left")
 B747CMD_fms1_ls_key_L5              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L5", fmsO.." Line Select Key 5-Left")
 B747CMD_fms1_ls_key_L6              = XLuaCreateCommand("laminar/B747/".. fmskeyid .. "/ls_key/L6", fmsO.." Line Select Key 6-Left")

--- a/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
+++ b/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
@@ -53,6 +53,7 @@ function simconfig_values()
 			active = "",
 			op_program = "",  --populated in the IDENT page of FMC via data found in version.lua
 			drag_ff = "+1.1/-3.5",
+			irs_align_time = 600,
 	}
 end
 

--- a/plugins/xtlua/scripts/B747.45.xt.fltCtrls/B747.45.xt.fltCtrls.lua
+++ b/plugins/xtlua/scripts/B747.45.xt.fltCtrls/B747.45.xt.fltCtrls.lua
@@ -121,8 +121,9 @@ simDR_flap_control_fail         = find_dataref("sim/operation/failures/rel_flap_
 
 simDR_engine_throttle_jet_all   = find_dataref("sim/cockpit2/engine/actuators/throttle_jet_rev_ratio_all")
 
-simDR_hyd_press_1_2               = find_dataref("laminar/B747/hydraulics/indicators/hydraulic_pressure_1_2_4")
+simDR_hyd_press_1_2             = find_dataref("laminar/B747/hydraulics/indicators/hydraulic_pressure_1_2_4")
 
+simDR_cg_adjust					= find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
 --*************************************************************************************--
 --** 				        CREATE READ-ONLY CUSTOM DATAREFS               	         **--
 --*************************************************************************************--
@@ -796,8 +797,20 @@ end
 
 ----- ELEVATOR TRIM ---------------------------------------------------------------------
 function B747_elevator_trim()
-
-     B747DR_elevator_trim_mid_ind = B747_rescale(200000, 1.0, 400000, 0.0, simDR_acf_weight_total_kg)
+	--Marauder28
+	cg_adjust = B747_rescale(-0.801623, 1.48, 0.835151, -1.48, simDR_cg_adjust)  --Base trim midpoint on CG position (FWD and AFT CG limits)
+	
+	if cg_adjust < 0 then
+		B747DR_elevator_trim_mid_ind = 0
+	elseif cg_adjust > 1 then
+		B747DR_elevator_trim_mid_ind = 1	
+	else
+		B747DR_elevator_trim_mid_ind = cg_adjust --simDR_cg_adjust
+	end
+	--Marauder28
+	
+	--B747DR_elevator_trim_mid_ind = B747_rescale(200000, 0.0, 400000, 1.0, simDR_acf_weight_total_kg)
+	--print("Trim Mid Ind = "..B747DR_elevator_trim_mid_ind)
 
 end
 
@@ -949,10 +962,12 @@ function B747_fltCtrols_EICAS_msg()
     end
 
     -- >CONFIG STAB
-   
     local midIndTop = B747_rescale(0.0, 1.5, 1.0, 6.0, B747DR_elevator_trim_mid_ind)
     local midIndBtm = midIndTop + 4.5
     local curTrim   = B747_rescale(-1.0, 15, 1.0, 0.0, simDR_elevator_trim)
+	--print("midIndTop = "..midIndTop)
+	--print("midIndBtm = "..midIndBtm)
+	--print("curTrim = "..curTrim)
     if (curTrim < midIndTop or curTrim > midIndBtm)              -- TODO:  VERIFY RANGE VALUES
         and simDR_all_wheels_on_ground == 1
         and simDR_ind_airspeed_kts_pilot < B747DR_airspeed_V1
@@ -1101,7 +1116,7 @@ end
 function B747_flight_start_deferred()
 
     --B747_init_gear_check_flag()                                                             -- REQUIRED BECAUSE "sim/flightmodel/failures/onground_all" IS NOT VALID AT LOAD
-    B747_elevator_trim()
+    --B747_elevator_trim()  --moved to after_physics loop
     B747_last_sim_sb_handle_pos = simDR_speedbrake_ratio_control
 
 end
@@ -1147,6 +1162,9 @@ if debug_fltctrls>0 then return end
 
     B747_fltctrls_monitor_AI()
     --print(collectgarbage("count")*1024)
+	
+	--Marauder28
+	B747_elevator_trim()  --constantly update the safe stab trim position based on CG
 end
 
 --function after_replay() end

--- a/plugins/xtlua/scripts/B747.68.xt.fms/B747.68.xt.fms.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/B747.68.xt.fms.lua
@@ -101,6 +101,7 @@ function toDMS(value,isLat)
   retVal=string.format(p .. "%03d`%02d.%1d",degrees,minutes,seconds*10)
   return retVal
 end
+
 function deferred_command(name,desc,realFunc)
 	return replace_command(name,realFunc)
 end
@@ -163,6 +164,7 @@ B747DR_fuel_preselect		= find_dataref("laminar/B747/fuel/preselect")
 B747DR_refuel				= find_dataref("laminar/B747/fuel/refuel")
 B747DR_fuel_add				= find_dataref("laminar/B747/fuel/add_fuel")
 
+--Marauder28
 --Used in ND DISPLAY
 simDR_latitude				= find_dataref("sim/flightmodel/position/latitude")
 simDR_longitude				= find_dataref("sim/flightmodel/position/longitude")
@@ -178,6 +180,16 @@ simDR_mach_copilot			= find_dataref("sim/cockpit2/gauges/indicators/mach_copilot
 simDR_total_air_temp		= find_dataref("sim/cockpit2/temperature/outside_air_LE_temp_degc")
 simDR_aircraft_hdg		 	= find_dataref("sim/cockpit2/gauges/indicators/heading_AHARS_deg_mag_pilot")
 
+--WB CG Info
+simDR_cgZ_ref_point			= find_dataref("sim/aircraft/weight/acf_cgZ_original")
+simDR_cgz_ref_to_default	= find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
+simDR_empty_weight			= find_dataref("sim/aircraft/weight/acf_m_empty")
+simDR_fuel_qty				= find_dataref("sim/flightmodel/weight/m_fuel")
+simDR_cg_adjust				= find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
+simDR_livery_path			= find_dataref("sim/aircraft/view/acf_livery_path")
+simDR_onground				= find_dataref("sim/flightmodel/failures/onground_any")
+--Marauder28
+
 --*************************************************************************************--
 --** 				        CREATE READ-WRITE CUSTOM DATAREFS                        **--
 --*************************************************************************************--
@@ -185,6 +197,7 @@ simDR_aircraft_hdg		 	= find_dataref("sim/cockpit2/gauges/indicators/heading_AHA
 -- CRT BRIGHTNESS DIAL ------------------------------------------------------------------
 B747DR_fms1_display_brightness      = deferred_dataref("laminar/B747/fms1/display_brightness", "number", B747_fms1_display_brightness_DRhandler)
 
+--Marauder28
 -- Holds all SimConfig options
 B747DR_simconfig_data					= deferred_dataref("laminar/B747/simconfig", "string")
 
@@ -218,6 +231,174 @@ if string.len(B747DR_simconfig_data) > 1 then
 else
 	simConfigData["data"] = json.decode("[]")
 end
+--Marauder28
+
+--Marauder28
+--Weight & Balance data
+wb = {
+		--Weights
+		OEW_weight				= 0,
+		fuel_CTR_0_weight		= 0,
+		fuel_L_main1_weight		= 0,
+		fuel_L_main2_weight		= 0,
+		fuel_R_main3_weight		= 0,
+		fuel_R_main4_weight		= 0,
+		fuel_L_rsv5_weight		= 0,
+		fuel_R_rsv6_weight		= 0,
+		fuel_stab7_weight		= 0,
+
+		-- Passenger Zones are defined A - E, A=First, B=Business, C-D-E=Economy split in 3 zones
+		passenger_zoneA_weight	= 0,  --defined via FMC passenger loading function
+		passenger_zoneB_weight	= 0,  --defined via FMC passenger loading function
+		passenger_zoneC_weight	= 0,  --defined via FMC passenger loading function
+		passenger_zoneD_weight	= 0,  --defined via FMC passenger loading function
+		passenger_zoneE_weight	= 0,  --defined via FMC passenger loading function
+		
+		--Payload/Cargo Zones
+		fwd_cargo_weight		= 0,  --defined via FMC cargo loading function
+		aft_cargo_weight		= 0,  --defined via FMC cargo loading function
+		bulk_cargo_weight		= 0,  --defined via FMC cargo loading function
+		
+		--Moment Arm Distances (inches from reference point [aircraft nose] stored in feet in aircraft .acf file)
+		OEW_distance				= 1243.32, --103.61 feet
+		fuel_CTR_0_distance			= 1008.00, --84.00 feet
+		fuel_L_main1_distance		= 1383.60, --115.30 feet
+		fuel_L_main2_distance		= 1140.00, --95.00 feet
+		fuel_R_main3_distance		= 1140.00, --95.00 feet
+		fuel_R_main4_distance		= 1383.60, --115.30 feet
+		fuel_L_rsv5_distance		= 1596.00, --133.00 feet
+		fuel_R_rsv6_distance		= 1596.00, --133.00 feet
+		fuel_stab7_distance			= 2412.00, --201.00 feet
+		-- Passenger Zone moment arm distances are an approximation using the middle of the Zone as a reference
+		passenger_zoneA_distance	= 260.00, --21.67 feet (23 First Class seats in the nose)
+		passenger_zoneB_distance	= 640.00, --53.33 feet (80 Business Class seats behind First Class, including the Upper Deck Business Class seats)
+		passenger_zoneC_distance	= 920.00, --76.67 feet (77 Economy Class seats)
+		passenger_zoneD_distance	= 1200.00, --100.00 feet (104 Economy Class seats)
+		passenger_zoneE_distance	= 1700.00, --141.67 feet (132 Economy Class seats)
+		
+		--Payload/Cargo Zone moment arm distances are an approximation using the middle of the Zone as a reference
+		fwd_cargo_distance			= 450,  --37.50 feet (5 pallets or 16 LD1/LD3 containers or combination totalling 26,490 KGS).  Approximation of Pax A + Pax B / 2.
+		aft_cargo_distance			= 1450.00,  --120.93 feet (4 pallets or 14 LD1/LD3 containers or combination totalling 22,938 KGS).  Approximation of Pax D + Pax E / 2.
+		bulk_cargo_distance			= 1900.00,  --158.33 feet (6,749 KGS).  In the tail of the aircraft beneath the rear galley.
+
+		--Calculated Results
+		stab_trim = 0,
+		cg_mac = 0,
+}
+
+--Calculate CG %MAC & Trim
+function calc_stab_trim(GW, CG_MAC)
+	local stab_trim = 0
+	
+	GW = GW * simConfigData["data"].kgs_to_lbs  --Formula uses LBS to calculate Stab TRIM.  GW passed in should always be in KGS.
+	--print("GWin = "..GW.." MACin = "..CG_MAC)
+
+	if GW > 1000 then
+		GW = GW / 1000  --GW must be in 1000s of LBS
+	end
+
+	stab_trim = (0.000000717 * GW^2 - 0.001217 * GW + 0.24) * CG_MAC + (-0.0000309 * GW^2 + 0.05558 * GW - 12.24)  --GW must be in 1000s of LBS
+	wb.stab_trim	= stab_trim
+	fmsModules["data"].stab_trim 	= string.format("%4.1f", wb.stab_trim)
+	--print("Trim = "..fmsModules["data"].stab_trim)
+end
+
+function calc_CGMAC()
+
+	local inch_to_meters	= 39.3700787
+	
+	--Setup initial weights
+	wb.OEW_weight				= simDR_empty_weight
+	wb.fuel_CTR_0_weight		= simDR_fuel_qty[0]
+	wb.fuel_L_main1_weight		= simDR_fuel_qty[1]
+	wb.fuel_L_main2_weight		= simDR_fuel_qty[2]
+	wb.fuel_R_main3_weight		= simDR_fuel_qty[3]
+	wb.fuel_R_main4_weight		= simDR_fuel_qty[4]
+	wb.fuel_L_rsv5_weight		= simDR_fuel_qty[5]
+	wb.fuel_R_rsv6_weight		= simDR_fuel_qty[6]
+	wb.fuel_stab7_weight		= simDR_fuel_qty[7]
+	wb.passenger_zoneD_weight	= B747DR_payload_weight  --Temporarily place all the passenger and payload weight close to the default XP CG until passenger & cargo loading is implemented
+
+	--CG variables (in inches from reference point)
+	local GW				= wb.OEW_weight + wb.fuel_CTR_0_weight + wb.fuel_L_main1_weight + wb.fuel_L_main2_weight + wb.fuel_R_main3_weight + wb.fuel_R_main4_weight
+								+ wb.fuel_L_rsv5_weight + wb.fuel_R_rsv6_weight + wb.fuel_stab7_weight + wb.passenger_zoneA_weight + wb.passenger_zoneB_weight
+								+ wb.passenger_zoneC_weight + wb.passenger_zoneD_weight + wb.passenger_zoneE_weight
+	local total_moment		= (wb.OEW_weight * wb.OEW_distance) + (wb.fuel_CTR_0_weight * wb.fuel_CTR_0_distance) + (wb.fuel_L_main1_weight * wb.fuel_L_main1_distance)
+								+ (wb.fuel_L_main2_weight * wb.fuel_L_main2_distance) + (wb.fuel_R_main3_weight * wb.fuel_R_main3_distance)
+								+ (wb.fuel_R_main4_weight * wb.fuel_R_main4_distance) + (wb.fuel_L_rsv5_weight * wb.fuel_L_rsv5_distance)
+								+ (wb.fuel_R_rsv6_weight * wb.fuel_R_rsv6_distance) + (wb.fuel_stab7_weight * wb.fuel_stab7_distance)
+								+ (wb.passenger_zoneA_weight * wb.passenger_zoneA_distance) + (wb.passenger_zoneB_weight * wb.passenger_zoneB_distance)
+								+ (wb.passenger_zoneC_weight * wb.passenger_zoneC_distance) + (wb.passenger_zoneD_weight * wb.passenger_zoneD_distance)
+								+ (wb.passenger_zoneE_weight * wb.passenger_zoneE_distance) + (wb.fwd_cargo_weight * wb.fwd_cargo_distance)
+								+ (wb.aft_cargo_weight * wb.aft_cargo_distance) + (wb.bulk_cargo_weight * wb.bulk_cargo_distance)
+	local CG				= total_moment / GW
+	local wing_root_chord	= 648.99996  --54.10 feet (from the aircraft .acf file)
+	local wing_tip_chord	= 159.99996  --13.40 feet (from the aircraft .acf file)
+	local wing_taper		= wing_tip_chord / wing_root_chord
+	local MAC				= (2/3) * wing_root_chord * ((1 + wing_taper + wing_taper^2) / (1 + wing_taper))
+	local LEMAC				= 1129.87932  --Approximately 94.18 feet as measured by where the default XP CG hits the 25% chord line at MAC and subtracting the 25% from the
+										  --default CG reference point of 1243.32 inches (103.61 feet)
+	local dist_default_CG	= 1243.32  --103.61 feet (from the aircraft .acf file)
+	local dist_aft_LEMAC	= CG - LEMAC
+	local CG_shift			= (dist_default_CG - CG) / inch_to_meters  --determine how far ahead or behind the OEW CG we are
+	local CG_MAC			= (dist_aft_LEMAC / MAC) * 100
+		
+	wb.cg_mac 				= CG_MAC
+	
+	fmsModules["data"].cg_mac 		= string.format("%2.0f", wb.cg_mac)
+	calc_stab_trim(GW, CG_MAC)
+
+	simDR_cg_adjust = CG_shift * -1  --Value is flipped from what is in the XP slider
+	
+	--print("Dist = "..dist_default_CG.." - "..CG)
+	--print("CG Shift = "..CG_shift)
+	--print("OEW weight = "..wb.OEW_weight)
+	--print("OEW distance = "..wb.OEW_distance)
+	--print("Fuel = "..simDR_fuel_qty[0])
+	--print("Fuel = "..wb.fuel_CTR_0_weight)
+	--print("CG %MAC = "..wb.cg_mac)
+	--print("Stab Trim = "..wb.stab_trim)
+	--print("GW = "..GW)
+end
+
+function inflight_update_CG()
+
+	local inch_to_meters	= 39.3700787
+	
+	--Setup initial weights
+	wb.OEW_weight				= simDR_empty_weight
+	wb.fuel_CTR_0_weight		= simDR_fuel_qty[0]
+	wb.fuel_L_main1_weight		= simDR_fuel_qty[1]
+	wb.fuel_L_main2_weight		= simDR_fuel_qty[2]
+	wb.fuel_R_main3_weight		= simDR_fuel_qty[3]
+	wb.fuel_R_main4_weight		= simDR_fuel_qty[4]
+	wb.fuel_L_rsv5_weight		= simDR_fuel_qty[5]
+	wb.fuel_R_rsv6_weight		= simDR_fuel_qty[6]
+	wb.fuel_stab7_weight		= simDR_fuel_qty[7]
+	wb.passenger_zoneD_weight	= B747DR_payload_weight  --Temporarily place all the passenger and payload weight close to the default XP CG until passenger & cargo loading is implemented
+
+	--CG variables (in inches from reference point)
+	local GW				= wb.OEW_weight + wb.fuel_CTR_0_weight + wb.fuel_L_main1_weight + wb.fuel_L_main2_weight + wb.fuel_R_main3_weight + wb.fuel_R_main4_weight
+								+ wb.fuel_L_rsv5_weight + wb.fuel_R_rsv6_weight + wb.fuel_stab7_weight + wb.passenger_zoneA_weight + wb.passenger_zoneB_weight
+								+ wb.passenger_zoneC_weight + wb.passenger_zoneD_weight + wb.passenger_zoneE_weight
+	local total_moment		= (wb.OEW_weight * wb.OEW_distance) + (wb.fuel_CTR_0_weight * wb.fuel_CTR_0_distance) + (wb.fuel_L_main1_weight * wb.fuel_L_main1_distance)
+								+ (wb.fuel_L_main2_weight * wb.fuel_L_main2_distance) + (wb.fuel_R_main3_weight * wb.fuel_R_main3_distance)
+								+ (wb.fuel_R_main4_weight * wb.fuel_R_main4_distance) + (wb.fuel_L_rsv5_weight * wb.fuel_L_rsv5_distance)
+								+ (wb.fuel_R_rsv6_weight * wb.fuel_R_rsv6_distance) + (wb.fuel_stab7_weight * wb.fuel_stab7_distance)
+								+ (wb.passenger_zoneA_weight * wb.passenger_zoneA_distance) + (wb.passenger_zoneB_weight * wb.passenger_zoneB_distance)
+								+ (wb.passenger_zoneC_weight * wb.passenger_zoneC_distance) + (wb.passenger_zoneD_weight * wb.passenger_zoneD_distance)
+								+ (wb.passenger_zoneE_weight * wb.passenger_zoneE_distance) + (wb.fwd_cargo_weight * wb.fwd_cargo_distance)
+								+ (wb.aft_cargo_weight * wb.aft_cargo_distance) + (wb.bulk_cargo_weight * wb.bulk_cargo_distance)
+	local CG				= total_moment / GW
+	local dist_default_CG	= 1243.32  --103.61 feet (from the aircraft .acf file)
+	local cg_shift			= (dist_default_CG - CG) / inch_to_meters  --determine how far ahead or behind the OEW CG we are
+
+	simDR_cg_adjust = cg_shift * -1  --Value is flipped from what is in the XP slider
+
+	--print("Dist = "..dist_default_CG.." - "..CG)
+	--print("CG Shift = "..cg_shift)
+end
+--Marauder28
 
 fmsPages={}
 --fmsPagesmall={}
@@ -227,7 +408,7 @@ fmsModules={} --set later
 function defaultFMSData()
   return {
   acarsInitString="{}",
-  fltno="*******",
+  fltno=string.rep("-", 8),
   fltdate="********",
   fltdep="****",
   fltdst="****",
@@ -237,8 +418,8 @@ function defaultFMSData()
   rpttimemm="**",
   acarsAddress="*******",
   atc="****",
-  grwt="***.*",
-  crzalt="*****",
+  grwt="***.*   ",
+  crzalt=string.rep("*", 5),
   clbspd="250",
   transpd="272",
   spdtransalt="10000",
@@ -257,30 +438,36 @@ function defaultFMSData()
   vb="*.*",
   vs="****",
   fuel="***.*",
-  zfw="***.*",
+  zfw="***.*   ",
   reserves="***.*",
   costindex="****",
-  crzcg="**.*",
+  crzcg="20.0",
   thrustsel="26",
   thrustn1="**.*",
   toflap="**",
   v1="***",
   vr="***",
   v2="***",
-  runway="*****",
-  coroute="*****",
+  runway=string.rep("-", 5),
+  coroute=string.rep("-", 10),
   grosswt="***.*",
   vref1="***",
   vref2="***",
-  irsLat="****`**.*",
-  irsLon="****`**.*",
+  irsLat=string.rep(" ", 9),
+  irsLon=string.rep(" ", 9),
   initIRSLat="****`**.*",
   initIRSLon="****`**.*",
   flapspeed="**/***",
-  airportpos="*****",
-  airportgate="*****",
-  preselectLeft="******",
-  preselectRight="******",
+  airportpos=string.rep("-", 4),
+  airportgate=string.rep(" ", 5),
+  preselectLeft=string.rep("-", 6),
+  preselectRight=string.rep("-", 6),
+  codata = string.rep("-", 6),
+  lastpos = string.rep(" ", 18),
+  sethdg = string.rep(" ", 4),
+  stepsize = "ICAO",
+  cg_mac = string.rep("-", 2),
+  stab_trim = string.rep(" ", 4),
 }
 end
 
@@ -417,6 +604,7 @@ fmsModules.fmsR=fmsR;
 
 B747DR_CAS_memo_status          = find_dataref("laminar/B747/CAS/memo_status")
 
+--Marauder28
 function getCurrentWayPoint(fms)
 
 	for i=1,table.getn(fms),1 do
@@ -548,6 +736,29 @@ function nd_speed_wind_display()
 	end
 end
 
+function aircraft_las_pos(phase)
+	file_location = simDR_livery_path.."B747-400_lastpos.dat"
+	--print("File = "..file_location)
+
+	if phase == "LOAD" then
+		--Load FMC last position
+		local file = assert(io.open(file_location, "r"))
+		if file ~= nil then
+			io.input(file)
+			fmsModules["data"].lastpos = io.read()
+			io.close(file)
+		end
+	else  --UNLOAD
+		local file = assert(io.open(file_location, "w+"))
+		if file ~= nil then
+			io.output(file)
+			io.write(irsSystem.getLat("gpsL") .." " .. irsSystem.getLon("gpsL"))
+			io.close(file)
+		end
+	end
+end
+--Marauder28
+
 function flight_start()
   if simDR_startup_running == 0 then
     irsSystem["irsL"]["aligned"]=false
@@ -562,7 +773,10 @@ function flight_start()
   
       irsSystem.align("irsR",true)
       
-    end 
+    end
+
+	--Ensure that CG location gets updated periodically so that the CG slider repositions automatically as fuel is burned during flight
+	run_at_interval(inflight_update_CG, 120)
 end
 
 debug_fms     = deferred_dataref("laminar/B747/debug/fms", "number")
@@ -594,9 +808,6 @@ function after_physics()
 --     for i =1,24,1 do
 --       print(string.byte(fms_style,i))
 --     end
-
-	--Get Current WEIGHT UNITS stored in FMC
-	--B747DR_weight_display_units = getFMSData("weightUnits")
 
     setNotifications()
     B747DR_FMSdata=json.encode(fmsModules["data"]["values"])--make the fms data available to other modules
@@ -640,5 +851,15 @@ function after_physics()
 
 	--Make simConfig data available to other modules
 	simConfigData["data"] = json.decode(B747DR_simconfig_data)
+	
+	--Ensure DR's are updated in time for use in calc_CGMAC()
+	local payload_weight = B747DR_payload_weight
+	local fuel_qty = simDR_fuel_qty
+	local simconfig = B747DR_simconfig_data
+	
+end
 
+function aircraft_unload()
+	aircraft_las_pos("UNLOAD")
+	simDR_cg_adjust = 0 --reset CG slider to neutral for future flights
 end

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.identpage.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.identpage.lua
@@ -21,7 +21,7 @@ fmsPages["IDENT"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be th
  "                        ",
  simConfigData["data"].op_program.."       ",
  "                        ",
- simConfigData["data"].drag_ff.."         ******",
+ simConfigData["data"].drag_ff.."         "..fmsModules["data"].codata,
  "------------------------",
  "<INDEX         POS INIT>"
     }
@@ -48,5 +48,6 @@ fmsPages["IDENT"]["templateSmall"]={
   
 fmsFunctionsDefs["IDENT"]={}
 fmsFunctionsDefs["IDENT"]["L6"]={"setpage","INITREF"}
+fmsFunctionsDefs["IDENT"]["R5"]={"setdata","codata"}
 fmsFunctionsDefs["IDENT"]["R6"]={"setpage","POSINIT"}
 

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
@@ -11,7 +11,7 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
   return {
   "   SIM CONFIGURATION    ",
   "                        ",
-  ""..display_weight_units,
+  ""..display_weight_units,  --.."             "..simConfigData["data"].irs_align_time,
   "                        ",
   "                        ",
   "                        ",
@@ -36,8 +36,8 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 
   return {
   "                        ",
-  "WEIGHT UNITS            ",
-  ""..display_weight_units,
+  "WEIGHT UNITS            ", --IRS ALIGN",
+  ""..display_weight_units,   --.."             mins",
   "                        ",
   "                        ",
   "                        ",
@@ -51,4 +51,5 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
   }
 end
 fmsFunctionsDefs["MAINTSIMCONFIG"]["L1"]={"setdata","weightUnits"}
+--fmsFunctionsDefs["MAINTSIMCONFIG"]["R1"]={"setdata","irsAlignTime"}
 fmsFunctionsDefs["MAINTSIMCONFIG"]["L6"]={"setpage","MAINT"}

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.perfinit.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.perfinit.lua
@@ -2,41 +2,94 @@ simDR_GRWT=find_dataref("sim/flightmodel/weight/m_total")
 simDR_fuel=find_dataref("sim/flightmodel/weight/m_fuel_total")
 simDR_payload=find_dataref("sim/flightmodel/weight/fixed")
 simDR_fuel_tanks=find_dataref("sim/flightmodel/weight/m_fuel") --res on 5 and 6
-simDR_cg=find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
+--simDR_cg=find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
+
+--Marauder28
+grwt_lineLg = ""
+grwt_lineSm = ""
+crzcg_lineLg = ""
+crzcg_lineSm = ""
+--Marauder28
 
 fmsPages["PERFINIT"]=createPage("PERFINIT")
 fmsPages["PERFINIT"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be this way
-    local grwtV=simDR_GRWT/1000
+	--Marauder28
+	local grwt = fmsModules["data"].grwt
+	local grwt_diff = 0  --used to track differences in manually entered GW and sim-provided GW
+	local zfw = fmsModules["data"].zfw
+	local calc_gw = string.format("%4.1f", (simDR_GRWT / 1000))
+	local calc_zfw = string.format("%4.1f", ((simDR_GRWT - simDR_fuel) / 1000))
+	
+	if not string.match(grwt, "***.*") then
+		calc_zfw = string.format("%4.1f", (tonumber(grwt) - simDR_fuel) / 1000)
+		grwt_diff = tonumber(grwt) - simDR_GRWT
+	end
+	
+	if not string.match(zfw, "***.*") then
+		zfw = string.format("%4.1f", zfw)
+		grwt = string.format("%4.1f", tonumber(zfw) + (simDR_fuel / 1000))
+	end
+	
+	if string.len(crzcg_lineLg) < 1 then
+		crzcg_lineSm = string.format("%4.1f%%", tonumber(fmsModules["data"].crzcg))
+	else
+		crzcg_lineLg = string.format("%4.1f%%", tonumber(fmsModules["data"].crzcg))
+		crzcg_lineSm = ""
+	end
+	--Marauder28
+	
+    --local grwtV=simDR_GRWT/1000
     local grfuelV=simDR_fuel/1000
-    local zfwV=(simDR_GRWT-simDR_fuel)/1000
+    --local zfwV=(simDR_GRWT-simDR_fuel)/1000
     local reservesV=(simDR_fuel_tanks[5]+simDR_fuel_tanks[6])/1000
     local jet_weightV=simDR_m_jettison/1000
+
 	if simConfigData["data"].weight_display_units == "LBS" then
-      grwtV=grwtV * simConfigData["data"].kgs_to_lbs
+	  --Marauder28
+	  if not string.match(grwt, "***.*") then grwt = string.format("%4.1f", tonumber(grwt) * simConfigData["data"].kgs_to_lbs) end
+	  if not string.match(zfw, "***.*") then zfw = string.format("%4.1f", tonumber(zfw) * simConfigData["data"].kgs_to_lbs) end
+	  calc_gw = string.format("%4.1f", tonumber(calc_gw) * simConfigData["data"].kgs_to_lbs)
+	  calc_zfw = string.format("%4.1f", tonumber(calc_zfw) * simConfigData["data"].kgs_to_lbs)	  
+	  --Marauder28
+
+      --grwtV=grwtV * simConfigData["data"].kgs_to_lbs
       grfuelV=grfuelV * simConfigData["data"].kgs_to_lbs
-      zfwV=zfwV * simConfigData["data"].kgs_to_lbs
+      --zfwV=zfwV * simConfigData["data"].kgs_to_lbs
       reservesV=reservesV * simConfigData["data"].kgs_to_lbs
       jet_weightV=jet_weightV * simConfigData["data"].kgs_to_lbs
     end
-    local grwt=string.format("%05.1f",grwtV)
+	
+    --local grwt=string.format("%05.1f",grwtV)
     local grfuel=string.format("%05.1f",grfuelV)
-    local zfw=string.format("%05.1f",zfwV)
+    --local zfw=string.format("%05.1f",zfwV)
     local reserves=string.format("%05.1f",reservesV)
     local jet_weight="     "
     if jet_weightV>0 then jet_weight=string.format("%05.1f",jet_weightV) end
+
+	--Marauder28
+	if string.match(grwt, "***.*") then
+		grwt_lineLg = "     "
+		grwt_lineSm = "<"..calc_gw
+	else
+		fmsModules["data"].grwt = simDR_GRWT + grwt_diff
+		grwt_lineLg = grwt
+		grwt_lineSm = "      "   --..calc_gw
+	end
+	--Marauder28
+	
     return{
 
  "       PERF INIT        ",
  "                        ",
- "".. grwt .."              "..fmsModules["data"]["crzalt"],
+ "".. grwt_lineLg .."              "..fmsModules["data"]["crzalt"],
  "                        ",
  ""..grfuel .. "              "..jet_weight ,
  "                        ",
- ""..zfw ,
+ ""..zfw,
  "                        ",
- ""..reserves .."              "..string.format("%03.1f",simDR_cg),
+ ""..reserves .."              "..crzcg_lineLg,
  "                        ",
- ""..fmsModules["data"]["costindex"] .."              ICAO", 
+ ""..fmsModules["data"]["costindex"] .."                "..fmsModules["data"].stepsize, 
  "                        ",
  "<INDEX       THRUST LIM>"
     }
@@ -45,17 +98,19 @@ fmsPages["PERFINIT"].getSmallPage=function(self,pgNo,fmsID)
     local lineA=" FUEL                   "
     if simDR_m_jettison>0 then
     lineA=" FUEL         RETARDANT "
-    end  
+    end
     return {
       "                        ",
-      " GR WT           CRZ ALT",
-      "                        ",
+      " GR WT ADV       CRZ ALT",
+	  grwt_lineSm,
+--      "                        ",
       lineA,
       "     CALC               ",
       " ZFW                    ",
       "                        ",
       " RESERVES         CRZ CG",
-      "                        ",
+--      "                        ",
+      "                   "..crzcg_lineSm,
       " COST INDEX    STEP SIZE",
       "                        ", 
       "                        ",
@@ -75,5 +130,6 @@ fmsFunctionsDefs["PERFINIT"]["L4"]={"setdata","reserves"}
 fmsFunctionsDefs["PERFINIT"]["L5"]={"setdata","costindex"}
 fmsFunctionsDefs["PERFINIT"]["L6"]={"setpage","INITREF"}
 fmsFunctionsDefs["PERFINIT"]["R1"]={"setdata","crzalt"}
---fmsFunctionsDefs["PERFINIT"]["R4"]={"setdata","crzcg"}
+fmsFunctionsDefs["PERFINIT"]["R4"]={"setdata","crzcg"}
+fmsFunctionsDefs["PERFINIT"]["R5"]={"setdata","stepsize"}
 fmsFunctionsDefs["PERFINIT"]["R6"]={"setpage","THRUSTLIM"}

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.posinit.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.posinit.lua
@@ -2,8 +2,11 @@ fmsPages["POSINIT"]=createPage("POSINIT")
 
 fmsPages["POSINIT"].getPage=function(self,pgNo,fmsID)
   if pgNo==1 then
-    
-    
+
+	--Marauder28
+	--Load last aircraft position (for this livery)
+	aircraft_las_pos("LOAD")
+
     fmsFunctionsDefs["POSINIT"]["R1"]={"getdata","lastpos"}
     
     fmsFunctionsDefs["POSINIT"]["R4"]={"getdata","gpspos"}
@@ -16,21 +19,26 @@ fmsPages["POSINIT"].getPage=function(self,pgNo,fmsID)
       fmsFunctionsDefs["POSINIT"]["L3"]=nil
       fmsFunctionsDefs["POSINIT"]["R5"]=nil
     end
+	if fmsModules["data"].sethdg == "---`" then
+		fmsFunctionsDefs["POSINIT"]["L5"]={"setdata","sethdg"}
+	else
+		fmsFunctionsDefs["POSINIT"]["L5"]=nil
+	end
     fmsFunctionsDefs["POSINIT"]["R6"]={"setpage","RTE1"}
     return {
-    "       POS INIT    1/3  ",
-    "                        ",
-    "      ".. irsSystem.calcLatA() .." "..irsSystem.calcLonA(),
-    "                        ",
-    fmsModules["data"]["airportpos"].."                   ",
-    "                        ",
+    "      POS INIT        1/3 ",
+    "                         ",
+    "      "..fmsModules["data"].lastpos,
+    "                         ",
+    fmsModules["data"]["airportpos"].."  "..fmsModules["data"].irsLat.." "..fmsModules["data"].irsLon,
+    "                         ",
     fmsModules["data"]["airportgate"].."                   ",
-    "                        ",
+    "                         ",
     string.format("%02d%02dz ",hh,mm).. irsSystem.getLat("gpsL") .." " .. irsSystem.getLon("gpsL"),
-    "                        ",
-    "---` ".. irsSystem.getInitLatPos().." ".. irsSystem.getInitLonPos(), 
-    "                        ",
-    "<INDEX            ROUTE>"
+    "                         ",
+    fmsModules["data"].sethdg.."  ".. irsSystem.getInitLatPos().." ".. irsSystem.getInitLonPos(), 
+    "                         ",
+    "<INDEX             ROUTE>"
     } 
   elseif pgNo==2 then 
     fmsFunctionsDefs["POSINIT"]["L2"]=nil
@@ -99,22 +107,22 @@ fmsPages["POSINIT"].getSmallPage=function(self,pgNo,fmsID)
   if pgNo==1 then
     local setIRS="                        "
     if B747DR_iru_status[0]==4 or B747DR_iru_status[1]==4 or B747DR_iru_status[2]==4 or irsSystem["setPos"]==false then
-      setIRS="SET HDG      SET IRS POS"
+      setIRS="SET HDG       SET IRS POS"
     end
     return {
-    "                        ",
-    "	             LAST POS",
-    "                        ",
-    "REF AIRPORT             ",
-    "                        ",
-    "GATE                    ",
-    "                        ",
-    "UTC (GPS)        GPS POS",
-    "                        ",
+    "                         ",
+    "                 LAST POS",
+    "                         ",
+    "REF AIRPORT              ",
+    "                         ",
+    "GATE                     ",
+    "                         ",
+    "UTC (GPS)         GPS POS",
+    "                         ",
     setIRS,
-    "                        ", 
-    "------------------------",
-    "                        "
+    "                         ", 
+    "-------------------------",
+    "                         "
     } 
   elseif pgNo==2 then 
     return {

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.takeoff.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.takeoff.lua
@@ -1,6 +1,9 @@
 B747DR_airspeed_V1                              = deferred_dataref("laminar/B747/airspeed/V1", "number")
 B747DR_airspeed_Vr                              = deferred_dataref("laminar/B747/airspeed/Vr", "number")
 B747DR_airspeed_V2                              = deferred_dataref("laminar/B747/airspeed/V2", "number")
+cg_lineLg	= ""
+cg_lineSm	= ""
+
 function roundToIncrement(number, increment)
 
     local y = number / increment
@@ -18,6 +21,20 @@ fmsPages["TAKEOFF"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be 
   local v1="***"
   local vr="***"
   local v2="***"
+  
+	--Marauder28
+	if string.len(cg_lineLg) == 0 then
+		if fmsModules["data"].cg_mac == "--" then
+			cg_lineSm = string.format("%s%%", fmsModules["data"].cg_mac)
+		else
+			cg_lineSm = string.format("%2.0f%%>", fmsModules["data"].cg_mac)
+		end
+	else
+		cg_lineLg = string.format("%2.0f%%", tonumber(fmsModules["data"].cg_mac))
+		cg_lineSm = ""
+	end
+	--Marauder28
+
   if B747DR_airspeed_V1<999 then
     v1=B747DR_airspeed_V1
     vr=B747DR_airspeed_Vr
@@ -33,7 +50,7 @@ fmsPages["TAKEOFF"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be 
   "                        ",
   string.format("FLAPS *  CLB *    %3d", v2),
   "                        ",
-  "               **.*  **%",
+  "                     "..cg_lineLg,
   "                        ",
   "            RW***       ", 
   "-----------------       ",
@@ -50,7 +67,7 @@ fmsPages["TAKEOFF"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be 
   "                        ",
   string.format("FLAPS *  CLB *    ***"),
   "                        ",
-  "               **.*  **%",
+  "                     "..cg_lineLg,
   "                        ",
   "            RW***       ", 
   "-----------------       ",
@@ -60,6 +77,19 @@ fmsPages["TAKEOFF"].getPage=function(self,pgNo,fmsID)--dynamic pages need to be 
 end
 
 fmsPages["TAKEOFF"].getSmallPage=function(self,pgNo,fmsID)
+
+  --Marauder28
+  local stab_trim = ""
+  
+  if string.len(cg_lineLg) > 0 then
+	  if fmsModules["data"].stab_trim ~= "    " then
+			stab_trim = string.format("%3.1f", tonumber(fmsModules["data"].stab_trim))
+	  else
+			stab_trim = fmsModules["data"].stab_trim
+	  end
+  end
+  --Marauder28
+  
     return{
 
 "                        ",
@@ -70,7 +100,8 @@ fmsPages["TAKEOFF"].getSmallPage=function(self,pgNo,fmsID)
 " THR REDUCTION    REF V2",
 "                     KT>",
 "               TRIM   CG",
-"                        ",
+--"                        ",
+"                "..stab_trim.."     "..cg_lineSm,
 "               POS SHIFT",
 "                   --00M", 
 "-----------------PRE-FLT",
@@ -85,4 +116,5 @@ fmsFunctionsDefs["TAKEOFF"]["R6"]={"setpage","POSINIT"}
 fmsFunctionsDefs["TAKEOFF"]["R1"]={"setdata","v1"}
 fmsFunctionsDefs["TAKEOFF"]["R2"]={"setdata","vr"}
 fmsFunctionsDefs["TAKEOFF"]["R3"]={"setdata","v2"}
+fmsFunctionsDefs["TAKEOFF"]["R4"]={"setdata","cg_mac"}
 fmsFunctionsDefs["TAKEOFF"]["L1"]={"setDref","flapsRef"}

--- a/plugins/xtlua/scripts/B747.68.xt.fms/irs/irs_system.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/irs/irs_system.lua
@@ -2,7 +2,7 @@ simDR_latitude=find_dataref("sim/flightmodel/position/latitude")
 simDR_longitude=find_dataref("sim/flightmodel/position/longitude")
 simDR_groundspeed=find_dataref("sim/flightmodel/position/groundspeed")
 B747DR_iru_mode_sel_pos         = find_dataref("laminar/B747/flt_mgmt/iru/mode_sel_dial_pos")
-local timeToAlign=600
+local timeToAlign=600  --simConfigData["data"].irs_align_time
 irs_L_status=find_dataref("laminar/B747/irs/line2") 
 irs_C_status=find_dataref("laminar/B747/irs/line3") 
 irs_R_status=find_dataref("laminar/B747/irs/line4") 
@@ -10,7 +10,6 @@ startLat=0
 startLon=0
 
 --IRS ND DISPLAY
-B747DR_ND_GPS_Line	= deferred_dataref("laminar/B747/irs/gps_display_line", "string")
 B747DR_ND_IRS_Line	= deferred_dataref("laminar/B747/irs/irs_display_line", "string")
 
 
@@ -128,7 +127,14 @@ function cancelAlign(func)
     stop_timer(func)
   end
 end
+
+function sleep(s)
+  local ntime = os.time() + s
+  repeat until os.time() > ntime
+end
+
 irsSystem.update=function()
+  --Marauder28
   --GPS/IRS DISPLAY
   B747DR_ND_GPS_Line = "GPS"
   
@@ -139,6 +145,20 @@ irsSystem.update=function()
   elseif irsSystem["irsR"]["aligned"] == true then
 	B747DR_ND_IRS_Line = "IRS (R)"
   end
+
+  --Update Set Hdg on FMC
+  if (B747DR_iru_mode_sel_pos[0] == 3 or B747DR_iru_mode_sel_pos[1] == 3 or B747DR_iru_mode_sel_pos[2] == 3) then
+	if tonumber(string.sub(fmsModules["data"].sethdg,1,3)) ~= nil then
+		sleep(2)
+		fmsModules["data"].sethdg = "---`"
+	else
+		fmsModules["data"].sethdg = "---`"
+	end
+  else
+	fmsModules["data"].sethdg = defaultFMSData().sethdg
+  end
+  --Marauder28
+  
   if irsSystem["irsL"]["aligned"] == true and irsSystem["irsC"]["aligned"] == true and irsSystem["irsR"]["aligned"] == true then
 	B747DR_ND_IRS_Line = "IRS (3)"
   end

--- a/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
+++ b/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
@@ -1331,6 +1331,7 @@ function getDistance(lat1,lon1,lat2,lon2)
   return retVal
 end
 local lastILSUpdate=0
+original_distance = -1
 function B747_fltmgmt_setILS()
   local modes=B747DR_radioModes
   local fmsSTR=fmsJSON
@@ -1370,12 +1371,28 @@ function B747_fltmgmt_setILS()
       --we have an airport as our dst
       local apdistance = getDistance(simDR_latitude,simDR_longitude,fms[table.getn(fms)][5],fms[table.getn(fms)][6])
       if apdistance>50 then return end
-      
+	  
+	  --Marauder28
+	  if original_distance == -1 then
+		original_distance = B747BR_totalDistance  --capture original flightplan distance
+	  end
+	  local pct_remaining = 100 - (((original_distance - B747BR_totalDistance) / original_distance) * 100)
+	  local dist_to_TOD = B747BR_totalDistance - B747BR_tod
+	  --print("Orig Dist = "..original_distance)
+	  --print("Dist Remain = "..B747BR_totalDistance)
+	  --if dist_to_TOD > 0 then print("Dist TOD = "..dist_to_TOD) end
+	  --print("Pct Remain = "..pct_remaining)
+	  --if (apdistance>=200) or (pct_remaining > 50) then
+	  --if dist_to_TOD >= 200 then --or pct_remaining > 50 then
+		--return    --more than 200nm away from TOD or less than half-way to DEST (used in NAV RAD auto-tune scenario #2)
+	  --end
+      --Marauder28
+	  
       found =false
      for i=table.getn(fms)-1,2,-1 do --last is the airport, before that go-around [may] be dup
 	--we have a fix coming in to the airport
        --if fms[i][2] == 512 then
-          local ap1Heading=getHeading(fms[i][5],fms[i][6],fms[table.getn(fms)][5],fms[table.getn(fms)][6])
+      local ap1Heading=getHeading(fms[i][5],fms[i][6],fms[table.getn(fms)][5],fms[table.getn(fms)][6])
 	  local ap2Heading=getHeading(fms[i-1][5],fms[i-1][6],fms[table.getn(fms)][5],fms[table.getn(fms)][6])
 	  local diffap=getHeadingDifference(ap1Heading,ap2Heading)
 	  local distance = getDistance(fms[i][5],fms[i][6],fms[table.getn(fms)][5],fms[table.getn(fms)][6])
@@ -1387,12 +1404,14 @@ function B747_fltmgmt_setILS()
 	      if diff<0 then diff=diff*-1 end
 	      local distance2 = getDistance(fms[table.getn(fms)][5],fms[table.getn(fms)][6],navAids[n][5],navAids[n][6])
 	      if diff<1 and diff<=bestDiff and distance2<10 then
-	      --print("navaid "..n.."->"..fms[i][8].."="..diff.." ".. navAids[n][1].." ".. navAids[n][2].." ".. navAids[n][3].." ".. navAids[n][4].." ".. navAids[n][5].." ".. navAids[n][6].." ".. navAids[n][7].." ".. navAids[n][8])
-	      bestDiff=diff
-	      --if targetFix == newTargetFix then 
-	      found=true
-	      newTargetFix=n
-	      hitI=i
+			  --print("navaid "..n.."->"..fms[i][8].."="..diff.." ".. navAids[n][1].." ".. navAids[n][2].." ".. navAids[n][3].." ".. navAids[n][4].." ".. navAids[n][5].." ".. navAids[n][6].." ".. navAids[n][7].." ".. navAids[n][8])
+			  bestDiff=diff
+			  print("bestdiff = "..bestDiff)
+			  --if targetFix == newTargetFix then 
+			  found=true
+			  newTargetFix=n
+			  print("newTargetFix = "..newTargetFix)
+			  hitI=i
 	      end
 	    end
 	  end


### PR DESCRIPTION
CG% MAC & TRIM calcs based on weight & distance from the datum (reference point) in PlaneMaker).
- Framework created for future use in loading passengers & cargo by zone.

FMC pages cleanup
- IDENT page
	-> 	Use new SimConfigData framework for default entries
	-> 	Display AIRAC information in correct format (still need to add AIRAC cycle number)
	-> 	Enable enry of CO DATA field
- POS INIT page
	->	LAST POS field has new functionality to load and (auto) save last known GPS coordinates (by livery)
	->	SET HDG now allows "dummy" entries for IRS alignment and blanks out 2 seconds after entry as specified in FCOM (no real func behind it other than display)
- NAV RADIO page
	->	Minor tweaks to the format of certain fields to match the FCOM specs
	->	Put in code for the frequency PARK display functionality but will require additional work in the XTLUA code that builds the NAVAIDS DB (navaids aren't availble 200 miles out)
- PERF INIT page
	->	GR WT now allows for LSK of pre-calulated weight.  If selected, it will auto-populate the ZFW.  Can also be user-entered which will change it to Large Font.
	->	ZFW is a required field that that can be LSK'd or manually entered.  Entry will re-calc the GR WT.
	->	CRZ CG field is now enabled for manual entry.  Currently only a dummy field but could get some love in the future to put actual flight logic behind it.
	->	If manual entries are made (i.e. overriding the default calcs), the display will take fuel flow into account (i.e. GR WT will reduce based on manual entry minus fuel burn instead of just basing it on sim GR WT).  If you hit either LSK again at any point after a manual entry it will replace the manual value with the calculated one.
	->	STEP SIZE field is now enabled and will respect entries based on FCOM parameters (0 - 9000 feet in 1000 feet increments, ICAO, etc.).  No actual flight logic tied to it yet.
- TAKE OFF REF page
	->	Added display of CG% and TRIM fields from new calcs performed in B747.68.xt.fms.lua.  CG% is avaialble via LSK (pre-calc'd) or manual entry (large font) and upon entry will display the TRIM setting.