### PR TITLE
New PAX/CARGO loading page in FMC

### DIFF
--- a/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
+++ b/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
@@ -54,6 +54,7 @@ function simconfig_values()
 			op_program = "",  --populated in the IDENT page of FMC via data found in version.lua
 			drag_ff = "+1.1/-3.5",
 			irs_align_time = 600,
+			stdPaxWeight = 120,  --In KGS
 	}
 end
 

--- a/plugins/xtlua/scripts/B747.45.xt.fltCtrls/B747.45.xt.fltCtrls.lua
+++ b/plugins/xtlua/scripts/B747.45.xt.fltCtrls/B747.45.xt.fltCtrls.lua
@@ -990,7 +990,8 @@ function B747_fltCtrols_EICAS_msg()
     -- >CONFIG STAB
     local midIndTop = B747_rescale(0.0, 1.5, 1.0, 6.0, B747DR_elevator_trim_mid_ind)
     local midIndBtm = midIndTop + 4.5
-    local curTrim   = B747_rescale(-1.0, 15, 1.0, 0.0, simDR_elevator_trim)
+    --local curTrim   = B747_rescale(-1.0, 15, 1.0, 0.0, simDR_elevator_trim)
+	local curTrim   = B747_rescale(-1.0, 0.0, 1.0, 15.0, simDR_elevator_trim)  --Swapped top and bottom of range for better comparisons
 	--print("midIndTop = "..midIndTop)
 	--print("midIndBtm = "..midIndBtm)
 	--print("curTrim = "..curTrim)

--- a/plugins/xtlua/scripts/B747.68.xt.fms/B747.68.xt.fms.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/B747.68.xt.fms.lua
@@ -194,6 +194,7 @@ simDR_fuel_qty				= find_dataref("sim/flightmodel/weight/m_fuel")
 simDR_cg_adjust				= find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
 simDR_livery_path			= find_dataref("sim/aircraft/view/acf_livery_path")
 simDR_onground				= find_dataref("sim/flightmodel/failures/onground_any")
+simDR_payload_weight		= find_dataref("sim/flightmodel/weight/m_fixed")
 --Marauder28
 
 --*************************************************************************************--
@@ -289,7 +290,7 @@ wb = {
 		passenger_zoneE_distance	= 1700.00, --141.67 feet (132 Economy Class seats)
 		
 		--Payload/Cargo Zone moment arm distances are an approximation using the middle of the Zone as a reference
-		fwd_cargo_distance			= 450,  --37.50 feet (5 pallets or 16 LD1/LD3 containers or combination totalling 26,490 KGS).  Approximation of Pax A + Pax B / 2.
+		fwd_cargo_distance			= 450,  --37.50 feet (5 pallets [5035 KGS] or 16 LD1/LD3 [1588 KGS] containers or combination totalling 26,490 KGS).  Approximation of Pax A + Pax B / 2.
 		aft_cargo_distance			= 1450.00,  --120.93 feet (4 pallets or 14 LD1/LD3 containers or combination totalling 22,938 KGS).  Approximation of Pax D + Pax E / 2.
 		bulk_cargo_distance			= 1900.00,  --158.33 feet (6,749 KGS).  In the tail of the aircraft beneath the rear galley.
 
@@ -335,7 +336,6 @@ function calc_CGMAC()
 	wb.fuel_L_rsv5_weight		= simDR_fuel_qty[5]
 	wb.fuel_R_rsv6_weight		= simDR_fuel_qty[6]
 	wb.fuel_stab7_weight		= simDR_fuel_qty[7]
-	wb.passenger_zoneD_weight	= B747DR_payload_weight  --Temporarily place all the passenger and payload weight close to the default XP CG until passenger & cargo loading is implemented
 
 	--CG variables (in inches from reference point)
 	local GW				= wb.OEW_weight + wb.fuel_CTR_0_weight + wb.fuel_L_main1_weight + wb.fuel_L_main2_weight + wb.fuel_R_main3_weight + wb.fuel_R_main4_weight
@@ -486,6 +486,22 @@ function defaultFMSData()
   stepsize = "ICAO",
   cg_mac = string.rep("-", 2),
   stab_trim = string.rep(" ", 4),
+  paxFirstClassA = string.rep("0", 2),
+  paxBusClassB = string.rep("0", 2),
+  paxEconClassC = string.rep("0", 2),
+  paxEconClassD = string.rep("0", 3),
+  paxEconClassE = string.rep("0", 3),
+  paxTotal = string.rep("0", 3),
+  paxWeightA = string.rep("0", 4),
+  paxWeightB = string.rep("0", 5),
+  paxWeightC = string.rep("0", 5),
+  paxWeightD = string.rep("0", 5),
+  paxWeightE = string.rep("0", 5),
+  paxWeightTotal = string.rep("0", 6),
+  cargoFwd = string.rep("0", 6),
+  cargoAft = string.rep("0", 6),
+  cargoBulk = string.rep("0", 5),
+  cargoTotal = string.rep("0", 6),
 }
 end
 
@@ -916,7 +932,11 @@ function after_physics()
 	local payload_weight = B747DR_payload_weight
 	local fuel_qty = simDR_fuel_qty
 	local simconfig = B747DR_simconfig_data
-	
+		
+end
+
+function aircraft_load()
+	simDR_cg_adjust = 0 --reset CG slider to begin current flight
 end
 
 function aircraft_unload()

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.groundhandling.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.groundhandling.lua
@@ -24,7 +24,7 @@ fmsPages["GNDHNDL"].getPage=function(self,pgNo,fmsID)
   "                        ",
   lineA,
   "                        ",
-  "<PUSH BACK              ",
+  "<PUSH BACK     PAX/CARGO>",
   "                        ",
   "                        ",
   "                        ",
@@ -55,6 +55,7 @@ fmsFunctionsDefs["GNDHNDL"]["L1"]={"setpage","GNDSRV"}
 fmsFunctionsDefs["GNDHNDL"]["L2"]={"setDref","CHOCKS"}
 fmsFunctionsDefs["GNDHNDL"]["L3"]={"setpage","PUSHBACK"} 
 fmsFunctionsDefs["GNDHNDL"]["L6"]={"setpage","INDEX"}
+fmsFunctionsDefs["GNDHNDL"]["R3"]={"setpage","PAXCARGO"}
 
 fmsPages["GNDSRV"]=createPage("GNDSRV")
 fmsPages["GNDSRV"].getPage=function(self,pgNo,fmsID)
@@ -80,7 +81,8 @@ fmsPages["GNDSRV"].getPage=function(self,pgNo,fmsID)
   "                        ",
   " "..lineA,
   "                        ",
-  lineC,
+  "                        ",
+  --lineC,
   "                        ",
   "  "..fmsModules["lastcmd"], 
   "                        ",
@@ -100,14 +102,14 @@ fmsPages["GNDSRV"].getSmallPage=function(self,pgNo,fmsID)
 	  else
 	    lineC = "                     KGS"
 	  end
-	else
-	    lineB = "Passengers              "
-	    lineC = "      x120kgs           "
-	    fmsFunctionsDefs["GNDSRV"]["L4"]={"setdata","passengers"}
+--	else
+--	    lineB = "Passengers              "
+--	    lineC = "      x120kgs           "
+--	    fmsFunctionsDefs["GNDSRV"]["L4"]={"setdata","passengers"}
 	end
 	if simConfigData["data"].weight_display_units == "LBS" then
 		lineA = "x1000LBS"
-		lineC = "      x265LBS           "
+--		lineC = "      x265LBS           "
 		
 	end
 	

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.pax-cargo.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.pax-cargo.lua
@@ -1,0 +1,119 @@
+--[[
+*****************************************************************************************
+* Program Script Name	:	B744.fms.pages.pax-cargo
+* Author Name			:	Marauder28
+*
+*   Revisions:
+*   -- DATE --	--- REV NO ---		--- DESCRIPTION ---
+*   2020-12-14	0.01a				Start of Dev
+*
+*****************************************************************************************
+*
+*****************************************************************************************
+--]]
+
+fmsPages["PAXCARGO"]=createPage("PAXCARGO")
+fmsPages["PAXCARGO"].getPage=function(self,pgNo,fmsID)
+	local weight_factor = 0
+	local paxA = 0
+	local paxB = 0
+	local paxC = 0
+	local paxD = 0
+	local paxE = 0
+	local cargo_fwd = 0
+	local cargo_aft = 0
+	local cargo_bulk = 0
+	local payload_weight = 0
+
+	if simConfigData["data"].weight_display_units == "LBS" then
+		weight_factor = simConfigData["data"].kgs_to_lbs
+	else
+		weight_factor = 1
+	end
+	
+	paxA = string.format("%-2d", tonumber(fmsModules["data"].paxFirstClassA))
+	paxB = string.format("%-2d", tonumber(fmsModules["data"].paxBusClassB))
+	paxC = string.format("%-2d", tonumber(fmsModules["data"].paxEconClassC))
+	paxD = string.format("%-3d", tonumber(fmsModules["data"].paxEconClassD))
+	paxE = string.format("%-3d", tonumber(fmsModules["data"].paxEconClassE))
+	cargo_fwd = string.format("%6d", tonumber(fmsModules["data"].cargoFwd) * weight_factor)
+	cargo_aft = string.format("%6d", tonumber(fmsModules["data"].cargoAft) * weight_factor)
+	cargo_bulk = string.format("%5d", tonumber(fmsModules["data"].cargoBulk) * weight_factor)
+	payload_weight = string.format("%6d", simDR_payload_weight * weight_factor)
+
+	if simDR_onGround == 0 then
+		fmsFunctionsDefs["PAXCARGO"]["L1"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["L2"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["L3"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["L4"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["L5"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["R1"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["R2"]=nil
+		fmsFunctionsDefs["PAXCARGO"]["R3"]=nil
+	else
+		fmsFunctionsDefs["PAXCARGO"]["L1"]={"setdata","paxFirstClassA"}
+		fmsFunctionsDefs["PAXCARGO"]["L2"]={"setdata","paxBusClassB"}
+		fmsFunctionsDefs["PAXCARGO"]["L3"]={"setdata","paxEconClassC"}
+		fmsFunctionsDefs["PAXCARGO"]["L4"]={"setdata","paxEconClassD"}
+		fmsFunctionsDefs["PAXCARGO"]["L5"]={"setdata","paxEconClassE"}
+		fmsFunctionsDefs["PAXCARGO"]["R1"]={"setdata","cargoFwd"}
+		fmsFunctionsDefs["PAXCARGO"]["R2"]={"setdata","cargoAft"}
+		fmsFunctionsDefs["PAXCARGO"]["R3"]={"setdata","cargoBulk"}
+	end
+	
+  return {
+  "    PAX / CARGO ("..simConfigData["data"].weight_display_units..")",
+  "                         ",
+  paxA.."                 "..cargo_fwd,
+  "                         ",
+  paxB.."                 "..cargo_aft,
+  "                         ",
+  paxC.."                  "..cargo_bulk,
+  "                         ",
+  paxD,
+  "           PAYLOAD="..payload_weight,
+  paxE,
+  "                         ",
+  "<GND HNDL                "
+  }
+end
+
+fmsPages["PAXCARGO"].getSmallPage=function(self,pgNo,fmsID)
+	local weight_factor = 0
+	local cargo_total = 0
+
+	if simConfigData["data"].weight_display_units == "LBS" then
+		weight_factor = simConfigData["data"].kgs_to_lbs
+	else
+		weight_factor = 1
+	end
+
+	pax_total = string.format("%3d", fmsModules["data"].paxTotal)
+	cargo_total = string.format("%6d", tonumber(fmsModules["data"].cargoTotal) * weight_factor)
+	
+  return {
+  "                         ",
+  "FIRST (A)       FWD CARGO",
+  "     (23)  (5P/16C)      ",
+  "BUS   (B)       AFT CARGO",
+  "     (80)  (4P/14C)      ",
+  "ECON  (C)      BULK CARGO",
+  "     (77)                ",
+  "ECON  (D)     --TOTALS-- ",
+  "    (104)    "..pax_total.." / "..cargo_total,
+  "ECON  (E)                ",
+  "    (132)                ",
+  "                         ",
+  "                         "
+  }
+end
+
+fmsFunctionsDefs["PAXCARGO"]["L1"]={"setdata","paxFirstClassA"}
+fmsFunctionsDefs["PAXCARGO"]["L2"]={"setdata","paxBusClassB"}
+fmsFunctionsDefs["PAXCARGO"]["L3"]={"setdata","paxEconClassC"}
+fmsFunctionsDefs["PAXCARGO"]["L4"]={"setdata","paxEconClassD"}
+fmsFunctionsDefs["PAXCARGO"]["L5"]={"setdata","paxEconClassE"}
+fmsFunctionsDefs["PAXCARGO"]["L6"]={"setpage","GNDHNDL"}
+fmsFunctionsDefs["PAXCARGO"]["R1"]={"setdata","cargoFwd"}
+fmsFunctionsDefs["PAXCARGO"]["R2"]={"setdata","cargoAft"}
+fmsFunctionsDefs["PAXCARGO"]["R3"]={"setdata","cargoBulk"}

--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.perfinit.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.perfinit.lua
@@ -1,6 +1,6 @@
 simDR_GRWT=find_dataref("sim/flightmodel/weight/m_total")
 simDR_fuel=find_dataref("sim/flightmodel/weight/m_fuel_total")
-simDR_payload=find_dataref("sim/flightmodel/weight/fixed")
+--simDR_payload=find_dataref("sim/flightmodel/weight/m_fixed")
 simDR_fuel_tanks=find_dataref("sim/flightmodel/weight/m_fuel") --res on 5 and 6
 --simDR_cg=find_dataref("sim/flightmodel/misc/cgz_ref_to_default")
 


### PR DESCRIPTION
PAX Loading
- Enter PAX by zone up to zone limit
- Entering “F” in First (A) zone will load aircraft at FULL capacity
- Entering “C” in First (A) zone will CLEAR all entries, including CARGO
- Entering more than (23) in First (A) zone will load the plane by zone in a round-robin fashion, starting in the front of the plane and continuing one PAX at a time through the other zones in order (A through E)
- Pressing LSK on a given line with 0 PAX and an empty scratchpad will load the maximum PAX for that zone
- For weight purposes, PAX are considered to be 120kg each which includes their baggage

CARGO Loading
- FWD and AFT CARGO can be enter via 2 methods:
    -> Entry of raw weight data (i.e. 12000)
    -> Entry of Pallet or Container data
        -->> 4P = 4 Pallets [96” x 125”] @ 5035kg each
        -->> 3C = 3 LD-1/LD-3 Containers @ 1588kg each
    -> Maximum Pallet and Container values are indicated in parentheses

General
- All weights are stored and calculated in KGS.  Display in LBS may include rounding errors incurred after changing display units.  This is true of ALL  screens where KGS/LBS can be toggled.
- After entering or changing values on this page, it is MANDATORY that the follwing items are updated:
    -> Gross Weight on the PERF INIT page.  This can be done by simply pressing the LSK key next to the existing Gross Weight and the field will update accordingly.
    -> CG% / TRIM on the TAKEOFF REF page.  This can be done by simply pressing the LSK key next to the existing CG% and the fields will update accordingly.
    -> Failure to do so may cause other flight stability issues which can have catestrophic effects on flight safety.

Also fixed a bug in the CONFIG STAB logic which caused incorrect CAS message to be displayed on Take-Off.