### PR TITLE
Fixed NO V SPD display staying on even after V SPDS are selected

### DIFF
--- a/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
+++ b/plugins/xtlua/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
@@ -204,7 +204,7 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		"<                        ",
 		" ENGINES(X)       FIN NBR",
 		"<                        ",
-		" THRUST REF (X) PFD STYLE",
+		" THRUST REF(X)  PFD STYLE",
 		"<    "..thrust_ref       .."                >",
 		"              (X)ND STYLE",
 		"                         >",


### PR DESCRIPTION
- Put NO V SPD graphics in their own groups (CRT & LCD)