### PR TITLE
Cost Index

### DIFF
--- a/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
+++ b/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
@@ -2362,8 +2362,10 @@ function vnavCruise()
 	local ci = tonumber( fmsData["costindex"] )
 	local ci_mach = 850
 	if(ci == nil or ci == "****") then
-		--was: spdval=tonumber(fmsData["crzspd"])/10
-		spdval = 85  --default
+		spdval=tonumber(fmsData["crzspd"])/10
+		if(spdval == nil) then
+			spdval = 85
+		end
 	else
 		-- mach numbers in thousands...
 		local lrcMach = 388.2356 + 0.6203 * gwtKG/1000 + 7.8061 * simDR_pressureAlt1/1000

--- a/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
+++ b/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
@@ -2363,7 +2363,7 @@ function vnavCruise()
 	local ci_mach = 850
 	if(ci == nil or ci == "****") then
 		--was: spdval=tonumber(fmsData["crzspd"])/10
-		spdval = 84  --default
+		spdval = 85  --default
 	else
 		-- mach numbers in thousands...
 		local lrcMach = 388.2356 + 0.6203 * gwtKG/1000 + 7.8061 * simDR_pressureAlt1/1000

--- a/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
+++ b/plugins/xtlua/scripts/B747.70.xt.autopilot/B747.70.xt.autopilot.lua
@@ -2363,7 +2363,7 @@ function vnavCruise()
 	local ci_mach = 850
 	if(ci == nil or ci == "****") then
 		--was: spdval=tonumber(fmsData["crzspd"])/10
-		spdval = 85  --default
+		spdval = 84  --default
 	else
 		-- mach numbers in thousands...
 		local lrcMach = 388.2356 + 0.6203 * gwtKG/1000 + 7.8061 * simDR_pressureAlt1/1000
@@ -2382,7 +2382,7 @@ function vnavCruise()
 		ci_mach = math.floor(ci_mach)
 		spdval = math.floor(ci_mach/10)
 	end
-		
+
       if (B747DR_ap_ias_dial_value ~=  spdval) and B747DR_ap_ias_mach_window_open == 0 and switchingIASMode==0 then 
 	switchingIASMode=1
 	simDR_autopilot_airspeed_is_mach = 1


### PR DESCRIPTION
Added a working cost index to support ECON cruise speeds. Dynamic adjustment of VNAV cruise airspeed based on cost index (CI) from the perf page.  Cost index airspeed is maximum range cruise (CI=0) to maximum mach airspeed (CI=9999). Accurately increases or decreases airspeed with headwind or tailwind, respectively. If no cost index is set, then default to M0.85. To obtain long range cruise (LRC) set cost index to 230.
