### PR TITLE
Fix RR DR's for EGT and throttle reference

### DIFF
--- a/plugins/xtlua/scripts/B747.42.xt.EEC/B747.42.xt.EEC.RR.lua
+++ b/plugins/xtlua/scripts/B747.42.xt.EEC/B747.42.xt.EEC.RR.lua
@@ -19,7 +19,8 @@ function RR(altitude_ft_in)
         B747DR_display_N1[i]=simDR_engine_N1_pct[i]
         B747DR_display_N2[i]=simDR_engine_N2_pct[i]
         B747DR_display_EPR[i]=simDR_engine_EPR[i]
-        B747DR_display_EGT[i]=simDR_engine_EGT_degC[i]
+        B747DR_display_EGT[i]=simDR_engn_EGT_c[i]
+        B747DR_throttle_resolver_angle[i]=simDR_throttle_ratio[i]
     end
     --[[local EPR = 0.0
 


### PR DESCRIPTION
- RR engines aren't implemented yet so passthrough existing XP DR's for EICAS displays