### PR TITLE
Engine 4 - Reverse Thrust does not engage

### DIFF
--- a/plugins/xtlua/scripts/B747.40.xt.engines/B747.40.xt.engines.lua
+++ b/plugins/xtlua/scripts/B747.40.xt.engines/B747.40.xt.engines.lua
@@ -353,7 +353,7 @@ function B747_thrust_rev_toggle_4_CMDhandler(phase, duration)
 				
 			else																		-- ENGINE 4 THROTTLE IS AT IDLE, OK TO TOGGLE PROP MODE FOR ALL ENGINES
 				-- TOGGLE PROP MODE
-				simDR_prop_mode[3] = 4 - simDR_prop_mode[1]															
+				simDR_prop_mode[3] = 4 - simDR_prop_mode[3]															
 			end
 				    	
 		end					


### PR DESCRIPTION
The engine 4 reverse thrust didn't engage as expected by pressing the button on my joystick.
The reverse state was coupled to the position of the reverser of engine 2. 