### PR TITLE
 Provide FMC control of Spill-Lights to deal with dark flightdeck panels.

### DIFF
--- a/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
+++ b/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
@@ -65,7 +65,11 @@ B747DR_efis_baro_ref_fo_switch_pos			= deferred_dataref("laminar/B747/efis/baro_
 -- Engine Type (crazytimitmtim)
 B747DR_engineType                               = deferred_dataref("laminar/B747/engines/type", "number")
 B747DR_hideGE						= deferred_dataref("laminar/B747/engines/hideGE", "number") 
-B747DR_hideRR						= deferred_dataref("laminar/B747/engines/hideRR", "number") 
+B747DR_hideRR						= deferred_dataref("laminar/B747/engines/hideRR", "number")
+
+-- Spill Lights
+B747DR_fmc_spill_lights					= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+
 B747DR_SNDoptions			        	= deferred_dataref("laminar/B747/fmod/options", "array[7]")
 --B747DR_SNDoptions_volume				= deferred_dataref("laminar/B747/fmod/options/volume", "array[8]")
 B747DR_SNDoptions_gpws					= deferred_dataref("laminar/B747/fmod/options/gpws", "array[16]")
@@ -90,6 +94,7 @@ function simconfig_values()
 					 capt_lwr = "NORM",  --EICAS PRI = 0, NORM = 1, ND = 2
 					 fo_inbd = "NORM",  --PFD = 0, NORM = 1, EICAS = 2
 					 fo_lwr = "NORM",  --ND = 0, NORM = 1, EICAS PRI = 2
+					 spill_lights = "NORM", --HI = 1, NORM = 0 --silvereagle
 			},
 			PLANE = {
 						model = "747-400",  --747-400, 747-400ER, 747-400F
@@ -276,6 +281,15 @@ function set_loaded_configs()
 	elseif simConfigData["data"].SIM.fo_lwr == "EICAS PRI" then
 		B747DR_flt_inst_lwr_disp_fo_sel_dial_pos = 2
 	end
+	
+	--silvereagle to end
+	if simConfigData["data"].SIM.spill_lights == "NORM" then
+		B747DR_fmc_spill_lights = 0
+	else
+		B747DR_fmc_spill_lights = 1
+	end
+	--silvereagle end
+
 	for key, value in pairs(simConfigData["data"].SOUND) do
 		setSoundOption(key,value)
 	end

--- a/plugins/xtlua_keysystems/init/scripts/B747.90.lighting/B747.90.lighting.lua
+++ b/plugins/xtlua_keysystems/init/scripts/B747.90.lighting/B747.90.lighting.lua
@@ -144,7 +144,8 @@ B747DR_flood_light_rheo_mcp             = deferred_dataref("laminar/B747/light/f
 B747DR_flood_light_rheo_aisle_stand     = deferred_dataref("laminar/B747/light/flood/rheostat/aisle_stand", "number", B747DR_flood_light_rheo_aisle_stand_DRhandler)
 B747DR_flood_light_rheo_overhead        = deferred_dataref("laminar/B747/light/flood/rheostat/overhead", "number", B747DR_flood_light_rheo_overhead_DRhandler)
 
-
+----- SPILL LIGHTS ----------------------------------------------------------------------
+B747DR_fmc_spill_lights			= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
 
 B747CMD_cockpitLightsOn		= deferred_command("laminar/B747/light/cockpit_lightsOn", "cockpit lights On", B747CMD_cockpitLightsOn_CMDhandler)
 B747CMD_cockpitLightsOff		= deferred_command("laminar/B747/light/cockpit_lightsOff", "cockpit lights Off", B747CMD_cockpitLightsOff_CMDhandler)

--- a/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/B744.fms.pages.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/B744.fms.pages.lua
@@ -14,6 +14,9 @@ B747DR_airspeed_flapsRef	= deferred_dataref("laminar/B747/airspeed/flapsRef", "n
 B747DR_refuel							= deferred_dataref("laminar/B747/fuel/refuel", "number")
 --Marauder28
 
+--Spill Lights
+B747DR_fmc_spill_lights		= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+
 fmsFunctions={}
 dofile("acars/acars.lua")
 
@@ -2148,6 +2151,20 @@ function fmsFunctions.setdata(fmsO,value)
 		simConfigData["data"].SIM.fo_lwr = fmsO.scratchpad
 		pushSimConfig(simConfigData["data"]["values"])
 	end
+	
+--silvereagle added to end
+    elseif value=="spillLights" then
+		if simConfigData["data"].SIM.spill_lights == "NORM" then
+			fmsO["scratchpad"] = "HI"
+			B747DR_fmc_spill_lights = 1
+		else	
+			fmsO["scratchpad"] = "NORM"
+			B747DR_fmc_spill_lights = 0
+		end
+		simConfigData["data"].SIM.spill_lights = fmsO.scratchpad
+		pushSimConfig(simConfigData["data"]["values"])
+--silvereagle end	
+		
 	elseif value=="simConfigSave" then
 			local file_location = simDR_livery_path.."B747-400_simconfig.dat"
 			--print("File = "..file_location)

--- a/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
@@ -11,7 +11,7 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["R3"]={"setdata","captLwr"}
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["R4"]={"setdata","foInbd"}
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["R5"]={"setdata","foLwr"}
-    fmsFunctionsDefs["MAINTSIMCONFIG"]["R6"]={"setdata","simConfigSave"}
+	    fmsFunctionsDefs["MAINTSIMCONFIG"]["R6"]={"setdata","simConfigSave"}
 		local weight_factor = 1
 		local display_weight_units = string.format("%-3s", simConfigData["data"].SIM.weight_display_units)
 		local irs_align_time = string.format("%-2d", simConfigData["data"].SIM.irs_align_time / 60)  --Mins
@@ -45,7 +45,36 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
 		"                        ",
 		"<MENU              SAVE>"
     }
-  elseif pgNo == 2 then
+
+--silvereagle added to end	
+    elseif pgNo == 2 then
+		fmsFunctionsDefs["MAINTSIMCONFIG"]["L1"]={"setdata","spillLights"}
+		fmsFunctionsDefs["MAINTSIMCONFIG"]["R6"]={"setdata","simConfigSave"}
+		local lineA = ""
+		if simConfigData["data"].SIM.spill_lights == "NORM" then
+			lineA = "NORM/  "
+		else
+			lineA = "    /HI"
+		end
+
+		return{
+		"       SIM CONFIG       ",
+		"                        ",
+		"<SPILL LIGHTS    " ..lineA,
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"------------------------",
+		"<MENU              SAVE>"
+		}
+--silvereagle end	
+		
+  elseif pgNo == 3 then --silvereagle
     fmsFunctionsDefs["MAINTSIMCONFIG"]["L1"]={"setDref","VNAVSPAUSE"}
     fmsFunctionsDefs["MAINTSIMCONFIG"]["L2"]={"setDref","PAUSEVAL"}
     fmsFunctionsDefs["MAINTSIMCONFIG"]["L3"]=nil
@@ -85,7 +114,7 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
     "                        ",
     "<MENU                   "
     }
-	elseif pgNo == 3 then
+	elseif pgNo == 4 then --silvereagle
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["L1"]={"setdata","model"}
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["L2"]={"setdata","aircraftType"}
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["L3"]={"setdata","engines"}
@@ -124,7 +153,7 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
 		}
 
 
-	elseif pgNo == 4 then
+	elseif pgNo == 5 then --silvereagle
 
 		-- SOUND OPTIONS (CRAZYTIMTIMTIM + MATT726)
 
@@ -193,7 +222,7 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		end
 
 		return {
-		"                     1/4",
+		"                     1/5", --silvereagle
 		" WGT UNITS    STD PAX WGT",
 		"<    "..display_weight_units,
 		" IRS ALIGN      CAPT INBD",
@@ -207,9 +236,34 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		"                        ",
 		"                        "
     }
-  elseif pgNo == 2 then
+
+--silvereagle added to end	
+	elseif pgNo == 2 then
+		if simConfigData["data"].SIM.spill_lights == "NORM" then
+			lineA = "                      HI"
+		else
+			lineA = "                 NORM   "
+		end
+
+	return{
+		"                     2/5",
+		"                        ",
+		lineA,
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        ",
+		"                        "
+		}
+--silvereagle end	
+		
+  elseif pgNo == 3 then --silvereagle
     return {
-      "                     2/4",
+      "                     3/5", --silvereagle
       "                        ",
       "                        ",
       "                        ",
@@ -223,7 +277,7 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
       "                        ",
       "                        "
       }
-	elseif pgNo == 3 then
+	elseif pgNo == 4 then --silvereagle
 		local thrust_ref = "EPR"
 		
 		if simConfigData["data"].PLANE.thrust_ref == "EPR" then
@@ -233,7 +287,7 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		end
 		
 		return {
-		"                     3/4",
+		"                     4/5",
 		" MODEL            AIRLINE",
 		"                        ",
 		" TYPE           CIVIL REG",
@@ -248,10 +302,10 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		"                        "
 		}
 
-	elseif pgNo == 4 then
+	elseif pgNo == 5 then --silvereagle
 
 		return {
-			"                     4/4",
+			"                     5/5",
 			"                        ",
 			"                        ",
 			"                        ",
@@ -270,6 +324,6 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 end
 
 fmsPages["MAINTSIMCONFIG"].getNumPages=function(self)
-  return 4
+  return 5
 end
 fmsFunctionsDefs["MAINTSIMCONFIG"]["L6"]={"setpage","INDEX"}

--- a/plugins/xtlua_keysystems/scripts/B747.90.xt.lighting/B747.90.xt.lighting.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.90.xt.lighting/B747.90.xt.lighting.lua
@@ -503,6 +503,9 @@ B747DR_flood_light_rheo_mcp             = deferred_dataref("laminar/B747/light/f
 B747DR_flood_light_rheo_aisle_stand     = deferred_dataref("laminar/B747/light/flood/rheostat/aisle_stand", "number", B747DR_flood_light_rheo_aisle_stand_DRhandler)
 B747DR_flood_light_rheo_overhead        = deferred_dataref("laminar/B747/light/flood/rheostat/overhead", "number", B747DR_flood_light_rheo_overhead_DRhandler)
 
+----- SPILL LIGHTS ----------------------------------------------------------------------
+B747DR_fmc_spill_lights					= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+
 function B747CMD_cockpitLightsOn_CMDhandler()
   --TODO Animate
   B747DR_flood_light_rheo_capt_panel=1
@@ -936,41 +939,69 @@ function B747_cabin_lights()
 
 end
 
-
-
-
-
+--silvereagle added/modified to end
 ----- SPILL LIGHTS ----------------------------------------------------------------------
 function B747_spill_lights()
+	if B747DR_fmc_spill_lights == 1 then
+		-- HERE FOR FMC "SIM CONFIG" PAGE "<SPILL LIGHTS HI" (BRIGHT DAY), STORM SWITCH HAS NO EFFECT
 
-    -- USE THE GENERIC LIGHT INDEX [63] AS A "POWER" VALUE FOR THE SPILL LIGHTS
+		-- USE THE GENERIC LIGHT INDEX [63] AS A "POWER" VALUE FOR THE SPILL LIGHTS
+		
+		-- TODO:  ADD BUS POWER LOGIC ?
 
-    -- TODO:  ADD BUS POWER LOGIC ?
+		local storm_light_brt_level = 8.0
+		local storm_light_level = storm_light_brt_level * simDR_generic_brightness_ratio[63]
 
-    -- BRIGHTNESS LEVEL FOR STORM LIGHTS
-    local storm_light_brt_level = 8.0
-	local storm_light_level = storm_light_brt_level * simDR_generic_brightness_ratio[63]
+		-- SET THE SPILL LIGHT LEVELS
+		B747DR_spill_light_capt_panel_flood[3]      = storm_light_level * 3
+		B747DR_spill_light_center_panel_flood[3]    = storm_light_level * 3
+		B747DR_spill_light_capt_map[3]              = B747DR_map_light_rheo_capt * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_capt_chart[3]            = B747DR_chart_light_rheo_capt * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_fo_panel_flood[3]        = storm_light_level * 3
+		B747DR_spill_light_fo_map[3]                = B747DR_map_light_rheo_fo * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_fo_chart[3]              = B747DR_chart_light_rheo_fo * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_observer_map[3]          = B747DR_map_light_rheo_observer * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_mcp_flood[3]             = storm_light_level
+		B747DR_spill_light_aisle_stand_flood[3]     = storm_light_level * 3
 
-    -- SET THE SPILL LIGHT LEVELS
-    B747DR_spill_light_capt_panel_flood[3]      = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level * 3, (B747DR_flood_light_rheo_capt_panel * simDR_generic_brightness_ratio[63]))
-    B747DR_spill_light_center_panel_flood[3]    = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level * 3, (B747DR_flood_light_rheo_capt_panel * simDR_generic_brightness_ratio[63]))
-    B747DR_spill_light_capt_map[3]              = B747DR_map_light_rheo_capt * simDR_generic_brightness_ratio[63]
-    B747DR_spill_light_capt_chart[3]            = B747DR_chart_light_rheo_capt * simDR_generic_brightness_ratio[63]
-    B747DR_spill_light_fo_panel_flood[3]        = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level * 3, (B747DR_flood_light_rheo_fo_panel * simDR_generic_brightness_ratio[63]))
-    B747DR_spill_light_fo_map[3]                = B747DR_map_light_rheo_fo * simDR_generic_brightness_ratio[63]
-    B747DR_spill_light_fo_chart[3]              = B747DR_chart_light_rheo_fo * simDR_generic_brightness_ratio[63]
-    B747DR_spill_light_observer_map[3]          = B747DR_map_light_rheo_observer * simDR_generic_brightness_ratio[63]
-    B747DR_spill_light_mcp_flood[3]             = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_mcp * simDR_generic_brightness_ratio[63]))
-    B747DR_spill_light_aisle_stand_flood[3]     = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level * 3, (B747DR_flood_light_rheo_aisle_stand * simDR_generic_brightness_ratio[63]))
+		--SET THE OVERHEAD FLOOD BRIGHTNESS LEVEL
+		simDR_panel_brightness_switch[0]            = storm_light_level
 
-    --SET THE OVERHEAD FLOOD BRIGHTNESS LEVEL
-    simDR_panel_brightness_switch[0]            = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, B747DR_flood_light_rheo_overhead)
+		-- SET THE MAG COMPASS SPILL LIGHT LEVEL
+		B747DR_spill_light_mag_compass_flood[3]     = simDR_panel_brightness_ratio[3]
+	
+	elseif B747DR_fmc_spill_lights == 0 then
+		-- HERE FOR "SIM CONFIG" PAGE "<SPILL LIGHTS NORM" (NOT BRIGHT DAY), STORM SWITCH HAS EFFECT
 
-    -- SET THE MAG COMPASS SPILL LIGHT LEVEL
-    B747DR_spill_light_mag_compass_flood[3]     = simDR_panel_brightness_ratio[3]
+		-- USE THE GENERIC LIGHT INDEX [63] AS A "POWER" VALUE FOR THE SPILL LIGHTS
+
+		-- TODO:  ADD BUS POWER LOGIC ?
+
+		-- BRIGHTNESS LEVEL FOR STORM LIGHTS
+		local storm_light_brt_level = 0.95
+		local storm_light_level = storm_light_brt_level * simDR_generic_brightness_ratio[63]
+
+		-- SET THE SPILL LIGHT LEVELS
+		B747DR_spill_light_capt_panel_flood[3]      = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_capt_panel * simDR_generic_brightness_ratio[63]))
+		B747DR_spill_light_center_panel_flood[3]    = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_capt_panel * simDR_generic_brightness_ratio[63]))
+		B747DR_spill_light_capt_map[3]              = B747DR_map_light_rheo_capt * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_capt_chart[3]            = B747DR_chart_light_rheo_capt * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_fo_panel_flood[3]        = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_fo_panel * simDR_generic_brightness_ratio[63]))
+		B747DR_spill_light_fo_map[3]                = B747DR_map_light_rheo_fo * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_fo_chart[3]              = B747DR_chart_light_rheo_fo * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_observer_map[3]          = B747DR_map_light_rheo_observer * simDR_generic_brightness_ratio[63]
+		B747DR_spill_light_mcp_flood[3]             = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_mcp * simDR_generic_brightness_ratio[63]))
+		B747DR_spill_light_aisle_stand_flood[3]     = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, (B747DR_flood_light_rheo_aisle_stand * simDR_generic_brightness_ratio[63]))
+
+		--SET THE OVERHEAD FLOOD BRIGHTNESS LEVEL
+		simDR_panel_brightness_switch[0]            = B747_ternary((B747DR_toggle_switch_position[0] <= 0.05), storm_light_level, B747DR_flood_light_rheo_overhead)
+
+		-- SET THE MAG COMPASS SPILL LIGHT LEVEL
+		B747DR_spill_light_mag_compass_flood[3]     = simDR_panel_brightness_ratio[3]
+
+	end
 end
-
-
+--silvereagle end
 
 ----- ANNUNCIATORS ----------------------------------------------------------------------
 function B747_annunciators()

--- a/plugins/xtlua_keysystems/scripts/B747.90.xt.lighting/B747.90.xt.lighting.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.90.xt.lighting/B747.90.xt.lighting.lua
@@ -504,7 +504,7 @@ B747DR_flood_light_rheo_aisle_stand     = deferred_dataref("laminar/B747/light/f
 B747DR_flood_light_rheo_overhead        = deferred_dataref("laminar/B747/light/flood/rheostat/overhead", "number", B747DR_flood_light_rheo_overhead_DRhandler)
 
 ----- SPILL LIGHTS ----------------------------------------------------------------------
-B747DR_fmc_spill_lights					= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+B747DR_fmc_spill_lights			= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
 
 function B747CMD_cockpitLightsOn_CMDhandler()
   --TODO Animate


### PR DESCRIPTION
FMC vs Storm Switch control of Spill Lights pros and cons:  Pros - easy to set and save the FMC Spill-Lights setting and leave it. Nice if you do mostly day flying. Don't have to mess with the Storm switch every time, as in my original approach. Original purpose of the Storm switch is retained.   Cons - None that I can think of.