### PR TITLE
Added Cockpit Seats Show/Hide

### DIFF
--- a/747-400_cockpit.obj
+++ b/747-400_cockpit.obj
@@ -24026,3 +24026,7 @@ ANIM_begin
 		TRIS	33630 1092
 	ANIM_end
 ANIM_end
+ANIM_begin
+	ANIM_show	0.0 0.0	laminar/B747/fmc/cockpit_seats_hide
+	ANIM_hide	1.0 1.0	laminar/B747/fmc/cockpit_seats_hide
+ANIM_end

--- a/objects/747_cockpit/Cockpit_Seats.obj
+++ b/objects/747_cockpit/Cockpit_Seats.obj
@@ -11483,5 +11483,9 @@ IDX10	8244 8258 8259 8244 8259 8245 8279 8277 8278 8279
 IDX	8278
 IDX	8280
 
+ANIM_begin
+	ANIM_show	0.0 0.0	laminar/B747/fmc/cockpit_seats_hide
+	ANIM_hide	1.0 1.0	laminar/B747/fmc/cockpit_seats_hide
 # Image: //objects/747_cockpit/Cockpit_Seats.png
-TRIS	0 31812
+	TRIS	0 31812
+ANIM_end

--- a/plugins/xtlua/init/scripts/B747.05.simconfig/B747.05.simconfig.lua
+++ b/plugins/xtlua/init/scripts/B747.05.simconfig/B747.05.simconfig.lua
@@ -50,3 +50,4 @@ B747DR_hideGear						= deferred_dataref("laminar/B747/objects/hideGear", "number
 B747DR_hideHStab						= deferred_dataref("laminar/B747/objects/hideHStab", "number")   
 B747DR_hideFuse						= deferred_dataref("laminar/B747/objects/hideFuse", "number")   
 B747DR_modernAlarms						= deferred_dataref("laminar/B747/fmod/options/modernAlarms", "number")
+B747DR_fmc_cockpit_seats_hide				= deferred_dataref("laminar/B747/fmc/cockpit_seats_hide", "number") --silvereagle

--- a/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
+++ b/plugins/xtlua/scripts/B747.05.xt.simconfig/B747.05.xt.simconfig.lua
@@ -67,8 +67,11 @@ B747DR_engineType                               = deferred_dataref("laminar/B747
 B747DR_hideGE						= deferred_dataref("laminar/B747/engines/hideGE", "number") 
 B747DR_hideRR						= deferred_dataref("laminar/B747/engines/hideRR", "number")
 
--- Spill Lights
-B747DR_fmc_spill_lights					= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+--silvereagle to end
+-- Misc.
+B747DR_fmc_spill_lights						= deferred_dataref("laminar/B747/fmc/spill_lights", "number")
+B747DR_fmc_cockpit_seats_hide				= deferred_dataref("laminar/B747/fmc/cockpit_seats_hide", "number")
+--silvereagle end
 
 B747DR_SNDoptions			        	= deferred_dataref("laminar/B747/fmod/options", "array[7]")
 --B747DR_SNDoptions_volume				= deferred_dataref("laminar/B747/fmod/options/volume", "array[8]")
@@ -95,6 +98,7 @@ function simconfig_values()
 					 fo_inbd = "NORM",  --PFD = 0, NORM = 1, EICAS = 2
 					 fo_lwr = "NORM",  --ND = 0, NORM = 1, EICAS PRI = 2
 					 spill_lights = "NORM", --HI = 1, NORM = 0 --silvereagle
+					 cockpit_seats_hide = "SHOW", --SHOW = 0 (default), HIDE = 1, (Useful to hide cockpit seats when using 3 monitors and the seats are in the way of viewing the instrument panel.) --silvereagle
 			},
 			PLANE = {
 						model = "747-400",  --747-400, 747-400ER, 747-400F
@@ -287,6 +291,12 @@ function set_loaded_configs()
 		B747DR_fmc_spill_lights = 0
 	else
 		B747DR_fmc_spill_lights = 1
+	end
+
+	if simConfigData["data"].SIM.cockpit_seats_hide == "SHOW" or simConfigData["data"].SIM.cockpit_seats_hide == null then
+		B747DR_fmc_cockpit_seats_hide = 0
+	else
+		B747DR_fmc_cockpit_seats_hide = 1
 	end
 	--silvereagle end
 

--- a/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/B744.fms.pages.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/B744.fms.pages.lua
@@ -14,8 +14,11 @@ B747DR_airspeed_flapsRef	= deferred_dataref("laminar/B747/airspeed/flapsRef", "n
 B747DR_refuel							= deferred_dataref("laminar/B747/fuel/refuel", "number")
 --Marauder28
 
---Spill Lights
-B747DR_fmc_spill_lights		= deferred_dataref("laminar/B747/fmc/spill_lights", "number") --silvereagle
+--silvereagle added to end
+-- Misc.
+B747DR_fmc_spill_lights		= deferred_dataref("laminar/B747/fmc/spill_lights", "number")
+B747DR_fmc_cockpit_seats_hide	= deferred_dataref("laminar/B747/fmc/cockpit_seats_hide", "number")
+--silvereagle end
 
 fmsFunctions={}
 dofile("acars/acars.lua")
@@ -2151,7 +2154,18 @@ function fmsFunctions.setdata(fmsO,value)
 		end
 		simConfigData["data"].SIM.spill_lights = fmsO.scratchpad
 		pushSimConfig(simConfigData["data"]["values"])
---silvereagle end	
+
+    elseif value=="cockpitSeatsHide" then
+		if B747DR_fmc_cockpit_seats_hide == 0 then
+			fmsO["scratchpad"] = "HIDE"
+			B747DR_fmc_cockpit_seats_hide = 1
+		else	
+			fmsO["scratchpad"] = "SHOW"
+			B747DR_fmc_cockpit_seats_hide = 0
+		end
+		simConfigData["data"].SIM.cockpit_seats_hide = fmsO.scratchpad
+		pushSimConfig(simConfigData["data"]["values"])
+--silvereagle end
 		
 	elseif value=="simConfigSave" then
 			local file_location = simDR_livery_path.."B747-400_simconfig.dat"

--- a/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
+++ b/plugins/xtlua_keysystems/scripts/B747.68.xt.fms/activepages/B744.fms.pages.maintsimconfig.lua
@@ -49,6 +49,7 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
 --silvereagle added to end	
     elseif pgNo == 2 then
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["L1"]={"setdata","spillLights"}
+		fmsFunctionsDefs["MAINTSIMCONFIG"]["L2"]={"setdata","cockpitSeatsHide"}
 		fmsFunctionsDefs["MAINTSIMCONFIG"]["R6"]={"setdata","simConfigSave"}
 		local lineA = ""
 		if B747DR_fmc_spill_lights==0 then
@@ -56,13 +57,19 @@ fmsPages["MAINTSIMCONFIG"].getPage=function(self,pgNo,fmsID)
 		else
 			lineA = "    /HI"
 		end
+		local lineB = ""
+		if B747DR_fmc_cockpit_seats_hide==0 then
+			lineB = "SHOW/    "
+		else
+			lineB = "    /HIDE"
+		end
 
 		return{
 		"       SIM CONFIG       ",
 		"                        ",
 		"<SPILL LIGHTS    " ..lineA,
 		"                        ",
-		"                        ",
+		"<COCKPIT SEATS " ..lineB,
 		"                        ",
 		"                        ",
 		"                        ",
@@ -239,11 +246,15 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 
 --silvereagle added to end	
 	elseif pgNo == 2 then
-		--if simConfigData["data"].SIM.spill_lights == "NORM" then
 		if B747DR_fmc_spill_lights==0 then	
 			lineA = "                      HI"
 		else
 			lineA = "                 NORM   "
+		end
+		if B747DR_fmc_cockpit_seats_hide==0 then				
+			lineB = "                    HIDE"			
+		else
+			lineB = "               SHOW     "		
 		end
 
 	return{
@@ -251,7 +262,7 @@ fmsPages["MAINTSIMCONFIG"].getSmallPage=function(self,pgNo,fmsID)
 		"                        ",
 		lineA,
 		"                        ",
-		"                        ",
+		lineB,
 		"                        ",
 		"                        ",
 		"                        ",


### PR DESCRIPTION
New feature to show or hide cockpit seats. Useful if using a monitor with a Lateral-Field-Of-View of about <= 60 degrees, and the seats are obscuring view of the instrument panel.  Control provide by FMC>SIM CONFIG>Page 2. Default is "Show".